### PR TITLE
refactor(music): MP-384 Song Titles Overlap In Music Detail

### DIFF
--- a/app/src/main/res/layout/music_controller.xml
+++ b/app/src/main/res/layout/music_controller.xml
@@ -8,11 +8,13 @@
 
     <TextView
         android:id="@+id/tv_song_title"
-        android:layout_width="wrap_content"
+        android:layout_width="@dimen/space_0dp"
         android:layout_height="wrap_content"
         android:fontFamily="@font/century_gothic_bold"
         android:text="@string/song_title"
         android:textSize="@dimen/font_25sp"
+        android:layout_marginEnd="@dimen/space_24dp"
+        app:layout_constraintEnd_toStartOf="@+id/imb_love"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 


### PR DESCRIPTION
## Update Items
- [ ] [[MP-384](https://args06.atlassian.net/browse/MP-384)] Song Titles Overlap In Music Detail

## Summary Description
- Change margin end and set constraint end for title 

## Screenshot (Optional)
### Before
- ![image](https://github.com/Nub-en-Nuber/NuberJam-Android/assets/49654730/2a6e3e1e-45cc-47c1-827f-c67dc831143f)

### After
- ![image](https://github.com/Nub-en-Nuber/NuberJam-Android/assets/49654730/14687ab5-ebea-4f91-99db-7713b426a94b)

## *Type of Change
- [ ] docs: Documentation only changes, README.md, Wiki
- [ ] feat: A new feature
- [ ] refactor: A code change that neither fixes a bug nor adds a feature
- [ ] test: Anything related to unit/integration testing
- [ ] revert: Revert a commit

## Type of Scope
- [ ] album: Changes that affect user packages
- [ ] music: Changes that affect music packages
- [ ] account: Changes that affect account packages
- [ ] favorite: Changes that affect favorite packages
- [ ] playlist: Changes that affect playlist packages
- [ ] playlist-detail: Changes that affect playlist-detail packages
- [ ] music-artist: Changes that affect music-artist packages
- [ ] general: all stuff except above
