### PR TITLE
refactor(favorite): 86cu98ypy Change empty state wording

### DIFF
--- a/app/src/main/java/com/example/nuberjam/ui/main/library/detail/DetailLibraryFragment.kt
+++ b/app/src/main/java/com/example/nuberjam/ui/main/library/detail/DetailLibraryFragment.kt
@@ -246,7 +246,7 @@ class DetailLibraryFragment : Fragment() {
             if (listMusic?.isEmpty() == true) {
                 msvPlaylistInner.showNuberJamEmptyState(
                     lottieJson = null,
-                    emptyMessage = getString(R.string.data_not_available)
+                    emptyMessage = getString(R.string.no_liked_song)
                 )
             } else {
                 musicAdapter.submitList(listMusic)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -40,6 +40,7 @@
     <string name="api_internet_error_message">No internet connection</string>
     <string name="edit_success_message">Edit successfully</string>
     <string name="data_not_available">Data not available</string>
+    <string name="no_liked_song">No liked song yet</string>
     <string name="form_empty_message">This field can\'t be empty!</string>
     <string name="login_failed_message">Incorrect username/email or password</string>
     <string name="login_success_message">Welcome, %s!</string>


### PR DESCRIPTION
## Update Items
- [x] [[86cu98ypy](https://app.clickup.com/t/86cu98ypy)] Empty state wording to "No liked song yet" in Favorite Feature

## Summary Description
- change empty state wording from "Data not available" to "No liked song yet"

## Screenshot (Optional)
### Before
<img width="416" alt="image" src="https://github.com/Nub-en-Nuber/NuberJam-Android/assets/49400463/47fc2fd7-cb5f-48e8-ae0f-d9cb97f06e82">

### After
![image](https://github.com/Nub-en-Nuber/NuberJam-Android/assets/49400463/7203e6d9-a67e-477e-bd2c-7a258057fa16)

## *Type of Change
- [ ] docs: Documentation only changes, README.md, Wiki
- [ ] feat: A new feature
- [x] refactor: A code change that neither fixes a bug nor adds a feature
- [ ] test: Anything related to unit/integration testing
- [ ] revert: Revert a commit

## Type of Scope
- [ ] album: Changes that affect user packages
- [ ] music: Changes that affect music packages
- [ ] account: Changes that affect account packages
- [x] favorite: Changes that affect favorite packages
- [ ] playlist: Changes that affect playlist packages
- [ ] playlist-detail: Changes that affect playlist-detail packages
- [ ] music-artist: Changes that affect music-artist packages
- [ ] general: all stuff except above
